### PR TITLE
s3 clients connection closed to avoid the connection leaks

### DIFF
--- a/src/main/kotlin/uk/gov/dwp/dataworks/egress/services/impl/DataServiceImpl.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/egress/services/impl/DataServiceImpl.kt
@@ -43,7 +43,11 @@ class DataServiceImpl(
 ) : DataService {
 
     override suspend fun egressObjects(specifications: List<EgressSpecification>): Boolean =
-        specifications.map { specification -> egressObjects(specification) }.all { it }
+        try {specifications.map { specification -> egressObjects(specification) }.all { it }}
+        finally {
+            s3Client.close()
+            s3AsyncClient.close()
+        }
 
     override suspend fun egressObjects(specification: EgressSpecification): Boolean =
         s3AsyncClient.listObjectsV2(listObjectsRequest(specification)).await().contents()


### PR DESCRIPTION
As DataEgress get connection timeout exception after every few days which suggests the connection leak. This PR closes S3Clients connections upon completion of all objects egress.