### PR TITLE
Update to services not to assume role when role_arn is empty

### DIFF
--- a/src/main/kotlin/uk/gov/dwp/dataworks/egress/services/impl/DataServiceImpl.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/egress/services/impl/DataServiceImpl.kt
@@ -217,13 +217,8 @@ class DataServiceImpl(
             build()
         }
 
-
     private suspend fun rtgSsmClient(specification: EgressSpecification): SsmClient =
-        specification.roleArn?.let {
-            assumedRoleSsmClientProvider(specification.roleArn)
-        } ?: run {
-            ssmClient
-        }
+        if (specification.roleArn.isNullOrBlank()) ssmClient else  assumedRoleSsmClientProvider(specification.roleArn)
 
     private fun targetContents(
         specification: EgressSpecification,

--- a/src/test/kotlin/uk/gov/dwp/dataworks/egress/services/impl/ManifestFileServiceImplTest.kt
+++ b/src/test/kotlin/uk/gov/dwp/dataworks/egress/services/impl/ManifestFileServiceImplTest.kt
@@ -216,10 +216,10 @@ class ManifestFileServiceImplTest: StringSpec() {
     companion object {
         private const val OBJECT_SIZE = "ObjectSize".length.toLong()
         private const val TODAYS_YYYYMMDD_FORMATTED_DATE_PLACEHOLDER = "\$TODAYS_YYYYMMDD_FORMATTED_DATE"
-        private const val SOURCE_BUCKET = "sourceBucket"
-        private const val SOURCE_PREFIX = "sourcePrefix/"+TODAYS_YYYYMMDD_FORMATTED_DATE_PLACEHOLDER
+        private const val SOURCE_BUCKET = "sourceBucket/"
+        private const val SOURCE_PREFIX = "sourcePrefix"
         private const val DESTINATION_BUCKET = "destinationBucket"
-        private const val DESTINATION_PREFIX = "destinationPrefix"
+        private const val DESTINATION_PREFIX = "destinationPrefix/"+ TODAYS_YYYYMMDD_FORMATTED_DATE_PLACEHOLDER
         private const val TRANSFER_TYPE = "S3"
         private const val ROLE_ARN = "roleArn"
         private const val PIPELINE_NAME = "pipelineName"


### PR DESCRIPTION
If role_arn field is created once and for some reason if we have to take this filed out of DynamoDB table, Terraform doesn't remove it instead it assign an empty string to it in which case the service fails as it can't assume role so updates services to not assume role when it's value is null or empty string